### PR TITLE
Add flag icons to language toggle and remove mobile menu transitions

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -149,19 +149,15 @@
     width: 100%;
     height: 100vh;
     background-color: var(--charcoal);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    transform-origin: top left;
     z-index: 998;
     pointer-events: none;
     opacity: 0;
-    transform: scaleY(0.98);
 }
 
 .mobileMenuOverlay.active {
     display: block;
     opacity: 1;
     pointer-events: all;
-    transform: scaleY(1);
 }
 
 
@@ -203,7 +199,6 @@
         max-width: 100%;
         height: 100vh;
         text-align: left;
-        transition: opacity 0.3s ease, transform 0.3s ease;
         box-shadow: none;
         padding: calc(var(--logo-height) + (var(--nav-padding-y) * 2) + 2rem) 2rem 1rem 2rem;
         overflow-y: auto;
@@ -213,52 +208,27 @@
         opacity: 0;
         transform: scale(0.95);
         pointer-events: none;
+        transition: none !important;
+        animation: none !important;
     }
     
     .navMenu.active {
         opacity: 1;
         transform: scale(1);
         pointer-events: all;
-        animation: menuExpand 0.3s ease forwards;
-    }
-
-    @keyframes menuExpand {
-        from {
-            transform: scale(0.95);
-        }
-        to {
-            transform: scale(1);
-        }
     }
     
     
     .navMenu li {
         padding: 0.5rem 0;
         width: 100%;
-        animation: fadeInUp 0.4s ease forwards;
         opacity: 0;
+        transition: none !important;
+        animation: none !important;
     }
-    
+
     .navMenu.active li {
         opacity: 1;
-    }
-    
-    .navMenu li:nth-child(1) { animation-delay: 0.1s; }
-    .navMenu li:nth-child(2) { animation-delay: 0.15s; }
-    .navMenu li:nth-child(3) { animation-delay: 0.2s; }
-    .navMenu li:nth-child(4) { animation-delay: 0.25s; }
-    .navMenu li:nth-child(5) { animation-delay: 0.3s; }
-    .navMenu li:nth-child(6) { animation-delay: 0.35s; }
-    
-    @keyframes fadeInUp {
-        from {
-            opacity: 0;
-            transform: translateY(20px);
-        }
-        to {
-            opacity: 1;
-            transform: translateY(0);
-        }
     }
     
     .navMenu a {
@@ -267,13 +237,14 @@
         display: flex;
         align-items: center;
         text-align: left;
-        transition: all 0.2s ease;
         position: relative;
         min-height: 48px;
         color: var(--white);
         font-weight: 500;
         letter-spacing: 0.5px;
         width: 100%;
+        transition: none !important;
+        animation: none !important;
     }
 
     .navMenu a:hover {
@@ -289,7 +260,6 @@
         width: 0;
         height: 2px;
         background-color: var(--primary-orange);
-        transition: width 0.3s ease;
     }
 
     .navMenu a:hover::after {
@@ -323,7 +293,6 @@
         transform: translateX(-50%);
         z-index: 1000;
         letter-spacing: -0.025em;
-        transition: all 0.3s ease;
         opacity: 0;
         pointer-events: none;
     }

--- a/src/components/LanguageToggle.module.css
+++ b/src/components/LanguageToggle.module.css
@@ -9,7 +9,7 @@
   cursor: pointer;
   transition: all 0.3s ease;
   margin-left: 15px;
-  min-width: 45px;
+  min-width: 60px;
   height: 35px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -19,10 +19,21 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
+.flagContainer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.flag {
+  border-radius: 2px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
 .langText {
   color: white;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 12px;
   letter-spacing: 0.5px;
 }
 
@@ -30,6 +41,7 @@
   .languageToggle {
     margin: 10px 0;
     width: 100%;
-    max-width: 100px;
+    max-width: 120px;
+    min-width: 80px;
   }
 }

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -12,15 +12,55 @@ export default function LanguageToggle() {
     localStorage.setItem('i18nextLng', newLang);
   };
 
+  const USAFlag = () => (
+    <svg className={styles.flag} viewBox="0 0 24 16" width="20" height="13">
+      <rect width="24" height="16" fill="#B22234"/>
+      <rect y="1" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="3" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="5" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="7" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="9" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="11" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="13" width="24" height="1" fill="#FFFFFF"/>
+      <rect y="15" width="24" height="1" fill="#FFFFFF"/>
+      <rect width="10" height="8" fill="#3C3B6E"/>
+    </svg>
+  );
+
+  const MexicoFlag = () => (
+    <svg className={styles.flag} viewBox="0 0 24 16" width="20" height="13">
+      <rect width="8" height="16" fill="#006847"/>
+      <rect x="8" width="8" height="16" fill="#FFFFFF"/>
+      <rect x="16" width="8" height="16" fill="#CE1126"/>
+      {/* Simplified Eagle Emblem */}
+      <g transform="translate(12, 8)">
+        {/* Eagle body */}
+        <ellipse cx="0" cy="0" rx="2" ry="1.5" fill="#8B4513"/>
+        {/* Eagle head */}
+        <circle cx="0" cy="-1" r="0.8" fill="#654321"/>
+        {/* Eagle beak */}
+        <path d="M0.8,-1 L1.2,-0.8 L0.8,-0.6 Z" fill="#FFA500"/>
+        {/* Eagle wings */}
+        <path d="M-2,-0.5 Q-2.8,0 -2,0.8 Q-1.2,0.2 -1.5,-0.5 Z" fill="#8B4513"/>
+        <path d="M2,-0.5 Q2.8,0 2,0.8 Q1.2,0.2 1.5,-0.5 Z" fill="#8B4513"/>
+        {/* Eagle tail */}
+        <path d="M-0.5,1.2 Q0,2.2 0.5,1.2 Q0,1.8 -0.5,1.2 Z" fill="#654321"/>
+      </g>
+    </svg>
+  );
+
   return (
-    <button 
+    <button
       className={styles.languageToggle}
       onClick={toggleLanguage}
       aria-label="Toggle language"
     >
-      <span className={styles.langText}>
-        {i18n.language === 'es' ? 'EN' : 'ES'}
-      </span>
+      <div className={styles.flagContainer}>
+        {i18n.language === 'es' ? <USAFlag /> : <MexicoFlag />}
+        <span className={styles.langText}>
+          {i18n.language === 'es' ? 'EN' : 'ES'}
+        </span>
+      </div>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Added USA and Mexico flag SVG icons to the language toggle component for better visual clarity
- Included detailed Mexican eagle emblem to distinguish from Italian flag
- Removed all transitions and animations from mobile hamburger menu for instant appearance/disappearance
- Updated language toggle styling to accommodate flag icons with proper spacing

## Changes Made

### Language Toggle Enhancements
- **Flag Icons**: Added inline SVG components for USA and Mexico flags
- **Mexican Eagle**: Included simplified but visible eagle emblem in center of Mexican flag
- **Layout Updates**: Added flag container with proper spacing between flag and text
- **Responsive Design**: Adjusted button width and mobile styling to accommodate flags

### Mobile Menu Performance
- **Instant Transitions**: Removed all CSS transitions and animations from mobile menu
- **Override Protection**: Added `!important` declarations to prevent inherited transitions
- **Clean Animation**: Menu now appears/disappears instantly without delays

## Technical Details
- Flag SVGs are 20×13px with rounded corners and subtle shadows
- USA flag shows when current language is Spanish (click to switch to English)
- Mexico flag shows when current language is English (click to switch to Spanish)
- All mobile menu animations forcefully disabled for immediate response

## Test plan
- [ ] Verify flag icons display correctly in language toggle
- [ ] Confirm Mexican flag eagle is visible and distinguishable from Italian flag
- [ ] Test language switching updates flag appropriately
- [ ] Verify mobile hamburger menu appears/disappears instantly
- [ ] Check responsive behavior on different screen sizes
- [ ] Test hover effects on desktop language toggle
- [ ] Verify mobile menu positioning and layout remain correct

🤖 Generated with [Claude Code](https://claude.ai/code)