### PR TITLE
Fix mobile navigation hover highlighting persistence

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -50,10 +50,6 @@
     position: relative;
 }
 
-.navMenu a:hover {
-    color: var(--light-orange);
-}
-
 .navMenu a::after {
     content: '';
     position: absolute;
@@ -65,8 +61,14 @@
     transition: width 0.3s ease;
 }
 
-.navMenu a:hover::after {
-    width: 100%;
+@media (hover: hover) {
+    .navMenu a:hover {
+        color: var(--light-orange);
+    }
+
+    .navMenu a:hover::after {
+        width: 100%;
+    }
 }
 
 .ctaNav {
@@ -81,10 +83,12 @@
     transition: all 0.3s ease;
 }
 
-.ctaNav:hover {
-    background-color: var(--light-orange);
-    color: var(--white) !important;
-    transform: translateY(-2px);
+@media (hover: hover) {
+    .ctaNav:hover {
+        background-color: var(--light-orange);
+        color: var(--white) !important;
+        transform: translateY(-2px);
+    }
 }
 
 .mobileCtaFixed {
@@ -247,9 +251,15 @@
         animation: none !important;
     }
 
-    .navMenu a:hover {
-        color: var(--primary-orange);
-        transform: translateX(10px);
+    @media (hover: hover) {
+        .navMenu a:hover {
+            color: var(--primary-orange);
+            transform: translateX(10px);
+        }
+
+        .navMenu a:hover::after {
+            width: 50%;
+        }
     }
 
     .navMenu a::after {
@@ -260,10 +270,6 @@
         width: 0;
         height: 2px;
         background-color: var(--primary-orange);
-    }
-
-    .navMenu a:hover::after {
-        width: 50%;
     }
     
     .menuIcon {
@@ -303,9 +309,11 @@
         pointer-events: all;
     }
 
-    .mobileCtaFixed:hover {
-        background-color: var(--light-orange);
-        transform: translateX(-50%) translateY(-2px);
+    @media (hover: hover) {
+        .mobileCtaFixed:hover {
+            background-color: var(--light-orange);
+            transform: translateX(-50%) translateY(-2px);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixed mobile navigation links staying highlighted after tapping in hamburger menu
- Wrapped all hover effects in `@media (hover: hover)` queries to prevent hover states from persisting on touch devices
- Maintains hover functionality on desktop while preventing sticky highlighting on mobile

## Changes Made
- Desktop navigation hover effects now only apply on hover-capable devices
- Mobile navigation hover effects properly scoped to hover-capable devices
- CTA button hover effects fixed for both desktop and mobile contexts
- Testimonials link and all other nav links no longer get stuck in highlighted state

## Test Plan
- [ ] Test mobile hamburger menu on iOS Safari - nav links should not stay highlighted after tapping
- [ ] Test mobile hamburger menu on Android Chrome - nav links should not stay highlighted after tapping  
- [ ] Test desktop navigation - hover effects should still work as expected
- [ ] Test CTA buttons on both mobile and desktop - hover effects should work appropriately for each context

## Technical Details
The issue was caused by CSS `:hover` pseudo-classes persisting on mobile devices after touch events. The `@media (hover: hover)` query ensures hover effects only apply on devices with actual hover capability (like desktop with mouse), preventing the sticky highlighting behavior on touch devices.

🤖 Generated with [Claude Code](https://claude.ai/code)